### PR TITLE
Support passing arguments to appium

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mocha-appium",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Run functional Mocha tests with wd and Appium.",
   "homepage": "https://github.com/wookiehangover/grunt-mocha-appium",
   "bugs": "https://github.com/wookiehangover/grunt-mocha-appium/issues",

--- a/tasks/lib/appium-launcher.js
+++ b/tasks/lib/appium-launcher.js
@@ -9,18 +9,11 @@ function run(options, cb) {
     if( err ){
       throw err;
     }
-    
     var appiumArgs = options.appiumArgs || [];
-    appiumArgs.push(
-      [
-        '--port',
-        port,
-      ]
-    );
-    console.log('Starting Appium with args ' + appiumArgs.join(" "));
+    appiumArgs.push('--port', port);
+    console.log('Starting Appium with args: ' + appiumArgs.join(" "));
 
     var child;
-
     child = spawn(APPIUM_PATH, appiumArgs);
     child.host = '0.0.0.0';
     child.port = port;

--- a/tasks/lib/appium-launcher.js
+++ b/tasks/lib/appium-launcher.js
@@ -9,12 +9,19 @@ function run(options, cb) {
     if( err ){
       throw err;
     }
-    console.log('Starting Appium on port ' + port);
+    
+    var appiumArgs = options.appiumArgs || [];
+    appiumArgs.push(
+      [
+        '--port',
+        port,
+      ]
+    );
+    console.log('Starting Appium with args ' + appiumArgs.join(" "));
+
     var child;
 
-    child = spawn(APPIUM_PATH, [
-      '--port', port,
-    ]);
+    child = spawn(APPIUM_PATH, appiumArgs);
     child.host = '0.0.0.0';
     child.port = port;
 

--- a/tasks/mocha-appium.js
+++ b/tasks/mocha-appium.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
     };
 
     // launch appium
-    appiumLauncher(_.pick(options, 'appiumPath'), function(err, appium){
+    appiumLauncher(_.pick(options, 'appiumPath', 'appiumArgs'), function(err, appium){
       grunt.log.writeln('Appium Running');
       if(err){
         appium.kill();


### PR DESCRIPTION
My system seems to have broken instruments, but passing "--native-instruments-lib" fixes it. This pull requests allows additional options to be passed to appium from the grunt file.
