### PR TITLE
1. Attach 'wd' and additional data to Mocha framework. 2. Fix promise Chanining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ grunt.initConfig({
       // Toggles wd's chain API, default:false
       useBrowserChainWrapper: false,
       // Path to appium executable, default:'appium'
-      appiumPath: 'appium'
+      appiumPath: 'appium',
+      // Attaches this object to mocha with additional data as you wish, default: {}
+      additionalMochaData: {env:'local', platform:'android' etc...} 
     },
     iphone: {
       src: ['test/*.js'],

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ grunt.initConfig({
       reporter: 'spec',
       timeout: 30e3,
       // Toggles wd's promises API, default:false
-      usePromises: false
+      usePromises: false,
+      // Toggles wd's chain API, default:false
+      useBrowserChainWrapper: false,
       // Path to appium executable, default:'appium'
       appiumPath: 'appium'
     },
@@ -84,6 +86,12 @@ Type: `Boolean` Default value: `false`
 If enabled, this will use the [promise-enabled wd browser
 API](https://github.com/admc/wd#promises-api) instead of the normal synchronous
 API.
+
+#### options.useBrowserChainWrapper
+
+Type: `String` Default value: `false`
+
+If enabled, will wrap the browser instance with chaining capability.
 
 #### options.appiumPath
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-mocha-appium",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Run functional Mocha tests with wd and Appium.",
   "homepage": "https://github.com/wookiehangover/grunt-mocha-appium",
   "bugs": "https://github.com/wookiehangover/grunt-mocha-appium/issues",

--- a/tasks/lib/appium-launcher.js
+++ b/tasks/lib/appium-launcher.js
@@ -23,7 +23,9 @@ function run(options, cb) {
     }
 
     child.stderr.on('data', function(data){
-      console.log(data.toString());
+      var parsedData = data.toString();
+      console.log(parsedData);
+      if(parsedData && parsedData.match(/deprecated/)){return;}
       badExit();
     })
 

--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -2,43 +2,43 @@ var Mocha = require('mocha');
 var Module = require('module');
 var path = require('path');
 
-module.exports = function(options, browser, grunt, fileGroup){
+module.exports = function (options, browser, wd, grunt, fileGroup) {
 
-  // Set up the mocha instance with options and files.
-  // This is copied from Mocha.prototype.run
-  // We need to do this because we need the runner, and the runner
-  //  is only held in that closure, not assigned to any instance properties.
-  var mocha = new Mocha(options);
+    // Set up the mocha instance with options and files.
+    // This is copied from Mocha.prototype.run
+    // We need to do this because we need the runner, and the runner
+    //  is only held in that closure, not assigned to any instance properties.
+    var mocha = new Mocha(options);
 
-  mocha.suite.on('pre-require', function (context, file, m) {
-    this.ctx.browser = browser;
-  });
+    mocha.suite.on('pre-require', function (context, file, m) {
+        this.ctx.browser = browser;
+        this.ctx.wd = wd;
+    });
 
-  grunt.file.expand({filter: 'isFile'}, fileGroup.src).forEach(function (f) {
-    var filePath = path.resolve(f);
-    if (Module._cache[filePath]) {
-      delete Module._cache[filePath];
+    grunt.file.expand({filter: 'isFile'}, fileGroup.src).forEach(function (f) {
+        var filePath = path.resolve(f);
+        if (Module._cache[filePath]) {
+            delete Module._cache[filePath];
+        }
+        mocha.addFile(filePath);
+    });
+
+    if (mocha.files.length) {
+        mocha.loadFiles();
     }
-    mocha.addFile(filePath);
-  });
 
-  if (mocha.files.length){
-    mocha.loadFiles();
-  }
+    var suite = mocha.suite;
+    options = mocha.options;
+    var runner = new Mocha.Runner(suite);
+    var reporter = new mocha._reporter(runner);
 
-  var suite = mocha.suite;
-  options = mocha.options;
-  var runner = new Mocha.Runner(suite);
-  var reporter = new mocha._reporter(runner);
+    runner.ignoreLeaks = options.ignoreLeaks;
+    runner.asyncOnly = options.asyncOnly;
 
-  runner.ignoreLeaks = options.ignoreLeaks;
-  runner.asyncOnly = options.asyncOnly;
+    if (options.grep) runner.grep(options.grep, options.invert);
+    if (options.globals) runner.globals(options.globals);
+    if (options.growl) mocha._growl(runner, reporter);
+    // Sigh.
 
-  if (options.grep) runner.grep(options.grep, options.invert);
-  if (options.globals) runner.globals(options.globals);
-  if (options.growl) mocha._growl(runner, reporter);
-  // Sigh.
-
-  return runner;
+    return runner;
 };
-

--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -2,7 +2,7 @@ var Mocha = require('mocha');
 var Module = require('module');
 var path = require('path');
 
-module.exports = function (options, browser, wd, grunt, fileGroup, additionalMochaData) {
+module.exports = function (options, browser, browserOpts, wd, grunt, fileGroup, additionalMochaData) {
     // Set up the mocha instance with options and files.
     // This is copied from Mocha.prototype.run
     // We need to do this because we need the runner, and the runner
@@ -11,6 +11,7 @@ module.exports = function (options, browser, wd, grunt, fileGroup, additionalMoc
 
     mocha.suite.on('pre-require', function (context, file, m) {
         this.ctx.browser = browser;
+        this.ctx.browserOpts = browserOpts;
         this.ctx.wd = wd;
         this.ctx.additionalMochaData = additionalMochaData;
     });

--- a/tasks/lib/mocha-runner.js
+++ b/tasks/lib/mocha-runner.js
@@ -2,8 +2,7 @@ var Mocha = require('mocha');
 var Module = require('module');
 var path = require('path');
 
-module.exports = function (options, browser, wd, grunt, fileGroup) {
-
+module.exports = function (options, browser, wd, grunt, fileGroup, additionalMochaData) {
     // Set up the mocha instance with options and files.
     // This is copied from Mocha.prototype.run
     // We need to do this because we need the runner, and the runner
@@ -13,6 +12,7 @@ module.exports = function (options, browser, wd, grunt, fileGroup) {
     mocha.suite.on('pre-require', function (context, file, m) {
         this.ctx.browser = browser;
         this.ctx.wd = wd;
+        this.ctx.additionalMochaData = additionalMochaData;
     });
 
     grunt.file.expand({filter: 'isFile'}, fileGroup.src).forEach(function (f) {

--- a/tasks/mocha-appium.js
+++ b/tasks/mocha-appium.js
@@ -102,35 +102,25 @@ module.exports = function(grunt) {
                 grunt.log.debug(' > \x1b[33m%s\x1b[0m: %s', meth, path, data || '');
             });
 
-            browser.init(opts, function(err){
-                if(err){
-                    grunt.fail.fatal(err);
-                    return;
-                }
 
-                var runner = mocha(options, browser, wd, grunt, fileGroup, additionalMochaData);
-                // Create the domain, and pass any errors to the mocha runner
-                var domain = createDomain();
-                domain.on('error', runner.uncaught.bind(runner));
+            var runner = mocha(options, browser, opts, wd, grunt, fileGroup, additionalMochaData);
+            // Create the domain, and pass any errors to the mocha runner
+            var domain = createDomain();
+            domain.on('error', runner.uncaught.bind(runner));
 
-                // Give selenium some breathing room
-                setTimeout(function(){
-                    // Selenium Download and Launch
-                    domain.run(function() {
-                        runner.run(function(err){
-                            browser.quit(function(){
-                                appium.kill();
-                                mochaDone(err);
-                                if (err) {
-                                    grunt.fail.warn('One or more tests failed.');
-                                }
-                            });
-                        });
+            // Give selenium some breathing room
+            setTimeout(function () {
+                // Selenium Download and Launch
+                domain.run(function () {
+                    runner.run(function (err) {
+                        appium.kill();
+                        mochaDone(err);
+                        if (err) {
+                            grunt.fail.warn('One or more tests failed.');
+                        }
                     });
-                }, 300);
-            });
-
+                });
+            }, 300);
         });
-
     }
 };

--- a/tasks/mocha-appium.js
+++ b/tasks/mocha-appium.js
@@ -105,7 +105,7 @@ module.exports = function(grunt) {
                     return;
                 }
 
-                var runner = mocha(options, browser, grunt, fileGroup);
+                var runner = mocha(options, browser, wd, grunt, fileGroup);
                 // Create the domain, and pass any errors to the mocha runner
                 var domain = createDomain();
                 domain.on('error', runner.uncaught.bind(runner));

--- a/tasks/mocha-appium.js
+++ b/tasks/mocha-appium.js
@@ -3,121 +3,128 @@
 "use strict";
 
 module.exports = function(grunt) {
-  var createDomain = require('domain').create;
-  var mocha = require('./lib/mocha-runner');
-  var mochaReporterBase = require('mocha/lib/reporters/base');
-  var wd = require('wd');
-  var appiumLauncher = require('./lib/appium-launcher');
-  var _ = grunt.util._;
+    var createDomain = require('domain').create;
+    var mocha = require('./lib/mocha-runner');
+    var mochaReporterBase = require('mocha/lib/reporters/base');
+    var wd = require('wd');
+    var appiumLauncher = require('./lib/appium-launcher');
+    var _ = grunt.util._;
 
-  grunt.registerMultiTask('mochaAppium', 'Run functional tests with mocha', function() {
-    var done = this.async();
-    // Retrieve options from the grunt task.
-    var options = this.options({
-      usePromises: false
-    });
+    grunt.registerMultiTask('mochaAppium', 'Run functional tests with mocha', function() {
+        var done = this.async();
+        // Retrieve options from the grunt task.
+        var options = this.options({
+            usePromises: false,
+            useBrowserChainWrapper: false
+        });
 
-    // We want color in our output, but when grunt-contrib-watch is used,
-    //  mocha will detect that it's being run to a pipe rather than tty.
-    // Mocha provides no way to force the use of colors, so, again, hack it.
-    var priorUseColors = mochaReporterBase.useColors;
-    if (options.useColors) {
-      mochaReporterBase.useColors = true;
-    }
-
-    // More agnostic -- just remove *all* the uncaughtException handlers;
-    //  they're almost certainly going to exit the process, which,
-    //  in this case, is definitely not what we want.
-    var uncaughtExceptionHandlers = process.listeners('uncaughtException');
-    process.removeAllListeners('uncaughtException');
-    var unmanageExceptions = function() {
-      uncaughtExceptionHandlers.forEach(
-        process.on.bind(process, 'uncaughtException'));
-    };
-    // Better, deals with more than just grunt?
-
-    // Restore prior state.
-    var restore = function() {
-      mochaReporterBase.useColors = priorUseColors;
-      unmanageExceptions();
-      done();
-    };
-
-    grunt.util.async.forEachSeries(this.files, function(fileGroup, next){
-      runTests(fileGroup, options, next);
-    }, restore);
-  });
-
-
-  function runTests(fileGroup, options, next){
-
-    // When we're done with mocha, dispose the domain
-    var mochaDone = function(errCount) {
-      var withoutErrors = (errCount === 0);
-      // Indicate whether we failed to the grunt task runner
-      next(withoutErrors);
-    };
-
-    // launch appium
-    appiumLauncher(_.pick(options, 'appiumPath', 'appiumArgs'), function(err, appium){
-      grunt.log.writeln('Appium Running');
-      if(err){
-        appium.kill();
-        grunt.fail.fatal(err);
-        return;
-      }
-
-      appium.stdout.on('data', function(data){
-        grunt.log.debug('Appium > '+ data.toString().replace('\n', ''));
-      });
-
-      appium.stderr.on('data', function(data){
-        // Appium has debug logging to stderr, so supress these logs with
-        // --verbose since they're not actual errors.
-        grunt.log.verbose.error('Appium > '+ data);
-      });
-
-      var remote = options.usePromises ? 'promiseRemote' : 'remote';
-      var browser = wd[remote](appium.host, appium.port);
-
-      var opts = _.omit(options, 'usePromises', 'appiumPath');
-
-      browser.on('status', function(info){
-        grunt.log.writeln('\x1b[36m%s\x1b[0m', info);
-      });
-
-      browser.on('command', function(meth, path, data){
-        grunt.log.debug(' > \x1b[33m%s\x1b[0m: %s', meth, path, data || '');
-      });
-
-      browser.init(opts, function(err){
-        if(err){
-          grunt.fail.fatal(err);
-          return;
+        // We want color in our output, but when grunt-contrib-watch is used,
+        //  mocha will detect that it's being run to a pipe rather than tty.
+        // Mocha provides no way to force the use of colors, so, again, hack it.
+        var priorUseColors = mochaReporterBase.useColors;
+        if (options.useColors) {
+            mochaReporterBase.useColors = true;
         }
 
-        var runner = mocha(options, browser, grunt, fileGroup);
-        // Create the domain, and pass any errors to the mocha runner
-        var domain = createDomain();
-        domain.on('error', runner.uncaught.bind(runner));
+        // More agnostic -- just remove *all* the uncaughtException handlers;
+        //  they're almost certainly going to exit the process, which,
+        //  in this case, is definitely not what we want.
+        var uncaughtExceptionHandlers = process.listeners('uncaughtException');
+        process.removeAllListeners('uncaughtException');
+        var unmanageExceptions = function() {
+            uncaughtExceptionHandlers.forEach(
+                process.on.bind(process, 'uncaughtException'));
+        };
+        // Better, deals with more than just grunt?
 
-        // Give selenium some breathing room
-        setTimeout(function(){
-          // Selenium Download and Launch
-          domain.run(function() {
-            runner.run(function(err){
-              browser.quit(function(){
-                appium.kill();
-                mochaDone(err);
-              });
-            });
-          });
-        }, 300);
-      });
+        // Restore prior state.
+        var restore = function() {
+            mochaReporterBase.useColors = priorUseColors;
+            unmanageExceptions();
+            done();
+        };
 
+        grunt.util.async.forEachSeries(this.files, function(fileGroup, next){
+            runTests(fileGroup, options, next);
+        }, restore);
     });
 
-  }
+
+    function runTests(fileGroup, options, next){
+
+        // When we're done with mocha, dispose the domain
+        var mochaDone = function(errCount) {
+            var withoutErrors = (errCount === 0);
+            // Indicate whether we failed to the grunt task runner
+            next(withoutErrors);
+        };
+
+        // launch appium
+        appiumLauncher(_.pick(options, 'appiumPath', 'appiumArgs'), function(err, appium){
+            grunt.log.writeln('Appium Running');
+            if(err){
+                appium.kill();
+                grunt.fail.fatal(err);
+                return;
+            }
+
+            appium.stdout.on('data', function(data){
+                grunt.log.debug('Appium > '+ data.toString().replace('\n', ''));
+            });
+
+            appium.stderr.on('data', function(data){
+                // Appium has debug logging to stderr, so supress these logs with
+                // --verbose since they're not actual errors.
+                grunt.log.verbose.error('Appium > '+ data);
+            });
+
+
+            var remote;
+            if(options.usePromises){
+                remote = options.useBrowserChainWrapper ? 'promiseChainRemote' : 'promiseRemote';
+            }
+            else{
+                remote = options.useBrowserChainWrapper ? 'asyncRemote' : 'remote';
+            }
+
+            var browser = wd[remote](appium.host, appium.port);
+
+            var opts = _.omit(options, 'usePromises', 'useBrowserChainWrapper', 'appiumPath');
+
+            browser.on('status', function(info){
+                grunt.log.writeln('\x1b[36m%s\x1b[0m', info);
+            });
+
+            browser.on('command', function(meth, path, data){
+                grunt.log.debug(' > \x1b[33m%s\x1b[0m: %s', meth, path, data || '');
+            });
+
+            browser.init(opts, function(err){
+                if(err){
+                    grunt.fail.fatal(err);
+                    return;
+                }
+
+                var runner = mocha(options, browser, grunt, fileGroup);
+                // Create the domain, and pass any errors to the mocha runner
+                var domain = createDomain();
+                domain.on('error', runner.uncaught.bind(runner));
+
+                // Give selenium some breathing room
+                setTimeout(function(){
+                    // Selenium Download and Launch
+                    domain.run(function() {
+                        runner.run(function(err){
+                            browser.quit(function(){
+                                appium.kill();
+                                mochaDone(err);
+                            });
+                        });
+                    });
+                }, 300);
+            });
+
+        });
+
+    }
 };
-
-

--- a/tasks/mocha-appium.js
+++ b/tasks/mocha-appium.js
@@ -121,6 +121,9 @@ module.exports = function(grunt) {
                             browser.quit(function(){
                                 appium.kill();
                                 mochaDone(err);
+                                if (err) {
+                                    grunt.fail.warn('One or more tests failed.');
+                                }
                             });
                         });
                     });

--- a/tasks/mocha-appium.js
+++ b/tasks/mocha-appium.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
         var done = this.async();
         // Retrieve options from the grunt task.
         var options = this.options({
-            additionalMochaData: null,
+            additionalMochaData: {},
             usePromises: false,
             useBrowserChainWrapper: false
         });

--- a/tasks/mocha-appium.js
+++ b/tasks/mocha-appium.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
         var done = this.async();
         // Retrieve options from the grunt task.
         var options = this.options({
+            additionalMochaData: null,
             usePromises: false,
             useBrowserChainWrapper: false
         });
@@ -89,7 +90,9 @@ module.exports = function(grunt) {
 
             var browser = wd[remote](appium.host, appium.port);
 
-            var opts = _.omit(options, 'usePromises', 'useBrowserChainWrapper', 'appiumPath');
+            var additionalMochaData = options.additionalMochaData;
+
+            var opts = _.omit(options, 'additionalMochaData', 'usePromises', 'useBrowserChainWrapper', 'appiumPath');
 
             browser.on('status', function(info){
                 grunt.log.writeln('\x1b[36m%s\x1b[0m', info);
@@ -105,7 +108,7 @@ module.exports = function(grunt) {
                     return;
                 }
 
-                var runner = mocha(options, browser, wd, grunt, fileGroup);
+                var runner = mocha(options, browser, wd, grunt, fileGroup, additionalMochaData);
                 // Create the domain, and pass any errors to the mocha runner
                 var domain = createDomain();
                 domain.on('error', runner.uncaught.bind(runner));


### PR DESCRIPTION
1. Basically, I added the following to `moch-runner.js`:

```
mocha.suite.on('pre-require', function (context, file, m) {
  this.ctx.browser = browser;
  this.ctx.wd = wd;
  this.ctx.additionalMochaData = additionalMochaData;
});
```

additionalMochaData can be passed in grunt options.
1. I fixed a syntax error and allowed chaining (e.g. browser.elementById('someId').tap().sleep(1000)).
   Fixed in `mocha-appium.js`

```
var remote;
if(options.usePromises){
  remote = options.useBrowserChainWrapper ? 'promiseChainRemote' : 'promiseRemote';
}
else{
  remote = options.useBrowserChainWrapper ? 'asyncRemote' : 'remote';
}
```
