### PR TITLE
Ignore reset error

### DIFF
--- a/tasks/lib/appium-launcher.js
+++ b/tasks/lib/appium-launcher.js
@@ -24,7 +24,11 @@ function run(options, cb) {
 
     child.stderr.on('data', function(data){
       console.log(data.toString());
-      badExit();
+      if (data.toString().match(/Could not reset simulator/)) {
+        console.log('Ignoring above error');
+      } else {
+        badExit();
+      }
     })
 
     child.stdout.on('data', function(data) {


### PR DESCRIPTION
Sometimes after tests have been run on an app, the commands to reset the phone to a previous state fails with the error:

```
error: Could not reset simulator. Leaving as is. Error: Command failed: An error was encountered processing the command (domain=com.apple.CoreSimulator.SimError, code=159):
```

Unable to erase contents and settings in current state: Booted

I don't see this as a problem as tests are often run on CI which boots phones from a clean state anyway.

This fix just ignores the above error so the process will pass if all the tests do.
